### PR TITLE
Make unique_impl_ptr honour const correctness

### DIFF
--- a/spimpl.h
+++ b/spimpl.h
@@ -89,7 +89,7 @@ namespace spimpl {
         template<class T>
         using default_copier_t = typename default_copier<T>::type;
 
-        template<class T, class D, class C>
+        template<class T, class D, class C = details::default_copier_t<T>>
         struct is_default_manageable: public std::integral_constant<bool,
             std::is_same<D, default_deleter_t<T>>::value &&
             std::is_same<C, default_copier_t<T>>::value
@@ -97,11 +97,11 @@ namespace spimpl {
     }
 
 
-    template<class T, class Deleter = details::default_deleter_t<T>, class Copier = details::default_copier_t<T>>
-    class impl_ptr
+    template<class T, class Deleter = details::default_deleter_t<T>>
+    class unique_impl_ptr
     {
-    private:
-        static_assert(!std::is_array<T>::value, "impl_ptr specialization for arrays is not implemented");
+        protected:
+        static_assert(!std::is_array<T>::value, "unique_impl_ptr specialization for arrays is not implemented");
         struct dummy_t_ {int dummy__;};
 
     public:
@@ -110,13 +110,288 @@ namespace spimpl {
         using reference = T&;
         using const_reference = typename std::add_const<T>::type &;
         using element_type = T;
-        using copier_type = typename std::decay<Copier>::type;
         using deleter_type = typename std::decay<Deleter>::type;
         using unique_ptr_type = std::unique_ptr<T, deleter_type>;
+        using is_default_manageable = details::is_default_manageable<T, deleter_type>;
+
+        SPIMPL_CONSTEXPR unique_impl_ptr() SPIMPL_NOEXCEPT
+        : ptr_(nullptr, deleter_type{}) {}
+
+        SPIMPL_CONSTEXPR unique_impl_ptr(std::nullptr_t) SPIMPL_NOEXCEPT
+        : unique_impl_ptr() {}
+
+        template<class D>
+        unique_impl_ptr(pointer p, D&& d,
+                 typename std::enable_if<
+                    std::is_convertible<D, deleter_type>::value,
+                    dummy_t_
+                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
+        : ptr_(std::move(p), std::forward<D>(d)) {}
+
+        template<class U>
+        unique_impl_ptr(U *u,
+                 typename std::enable_if<
+                    std::is_convertible<U*, pointer>::value
+                        && is_default_manageable::value,
+                    dummy_t_
+                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
+        : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
+
+#ifndef SPIMPL_NO_CPP11_DEFAULT_MOVE_SPEC_FUNC
+        unique_impl_ptr(unique_impl_ptr&& r) SPIMPL_NOEXCEPT = default;
+#else
+        unique_impl_ptr(unique_impl_ptr&& r) SPIMPL_NOEXCEPT
+        : ptr_(std::move(r.ptr_)) {}
+#endif
+
+#ifdef SPIMPL_HAS_AUTO_PTR
+        template<class U>
+        unique_impl_ptr(std::auto_ptr<U>&& u,
+                 typename std::enable_if<
+                    std::is_convertible<U*, pointer>::value
+                        && is_default_manageable::value,
+                    dummy_t_
+                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
+        : ptr_(u.release(), &details::default_delete<T>) {}
+#endif
+
+        template<class U>
+        unique_impl_ptr(std::unique_ptr<U>&& u,
+                 typename std::enable_if<
+                    std::is_convertible<U*, pointer>::value
+                        && is_default_manageable::value,
+                    dummy_t_
+                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
+        : ptr_(u.release(), &details::default_delete<T>) {}
+
+        template<class U, class D>
+        unique_impl_ptr(std::unique_ptr<U, D>&& u,
+                 typename std::enable_if<
+                    std::is_convertible<U*, pointer>::value
+                        && std::is_convertible<D, deleter_type>::value,
+                    dummy_t_
+                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
+        : ptr_(std::move(u)) {}
+
+        template<class U, class D>
+        unique_impl_ptr(unique_impl_ptr<U, D>&& u,
+                 typename std::enable_if<
+                    std::is_convertible<U*, pointer>::value
+                        && std::is_convertible<D, deleter_type>::value,
+                    dummy_t_
+                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
+        : ptr_(std::move(u.ptr_)) {}
+
+        unique_impl_ptr(const unique_impl_ptr<T, Deleter>&) = delete;
+
+#ifndef SPIMPL_NO_CPP11_DEFAULT_MOVE_SPEC_FUNC
+        unique_impl_ptr& operator= (unique_impl_ptr&& r) SPIMPL_NOEXCEPT = default;
+#else
+        unique_impl_ptr& operator= (unique_impl_ptr&& r) SPIMPL_NOEXCEPT {
+            ptr_ = std::move(r.ptr_);
+            return *this;
+        }
+#endif
+
+#ifdef SPIMPL_HAS_AUTO_PTR
+        template<class U>
+        typename std::enable_if<
+            std::is_convertible<U*, pointer>::value
+                && is_default_manageable::value,
+            unique_impl_ptr&
+        >::type operator= (std::auto_ptr<U>&& u) SPIMPL_NOEXCEPT
+        {
+            return operator=(unique_impl_ptr(std::move(u)));
+        }
+#endif
+
+        template<class U>
+        typename std::enable_if<
+            std::is_convertible<U*, pointer>::value
+                && is_default_manageable::value,
+            unique_impl_ptr&
+        >::type operator= (std::unique_ptr<U>&& u) SPIMPL_NOEXCEPT
+        {
+            return operator=(unique_impl_ptr(std::move(u)));
+        }
+
+        reference operator=(const unique_impl_ptr<T, Deleter>&) = delete;
+
+        reference operator*() { return *ptr_; }
+        const_reference operator*() const { return *ptr_; }
+
+        pointer operator->() SPIMPL_NOEXCEPT { return get(); }
+        const_pointer operator->() const SPIMPL_NOEXCEPT { return get(); }
+
+        pointer get() SPIMPL_NOEXCEPT { return ptr_.get(); }
+        const_pointer get() const SPIMPL_NOEXCEPT { return ptr_.get(); }
+
+        void swap(unique_impl_ptr& u) SPIMPL_NOEXCEPT
+        {
+            using std::swap;
+            ptr_.swap(u.ptr_);
+        }
+
+        pointer release() SPIMPL_NOEXCEPT { return ptr_.release(); }
+
+        unique_ptr_type release_unique() SPIMPL_NOEXCEPT { return std::move(ptr_); }
+
+        explicit operator bool() const SPIMPL_NOEXCEPT { return static_cast<bool>(ptr_); }
+
+        typename std::remove_reference<deleter_type>::type& get_deleter() SPIMPL_NOEXCEPT { return ptr_.get_deleter(); }
+        const typename std::remove_reference<deleter_type>::type& get_deleter() const SPIMPL_NOEXCEPT { return ptr_.get_deleter(); }
+
+    protected:
+        unique_ptr_type ptr_;
+    };
+
+
+    template<class T, class D>
+    inline void swap(unique_impl_ptr<T, D>& l, unique_impl_ptr<T, D>& r) SPIMPL_NOEXCEPT
+    {
+        l.swap(r);
+    }
+
+
+    template <class T1, class D1, class T2, class D2>
+    inline bool operator==(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
+    {
+        return l.get() == r.get();
+    }
+
+    template <class T1, class D1, class C1, class T2, class D2>
+    inline bool operator!=(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
+    {
+        return !(l == r);
+    }
+
+    template <class T1, class D1, class T2, class D2>
+    inline bool operator< (const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
+    {
+        using P1 = typename unique_impl_ptr<T1, D1>::pointer;
+        using P2 = typename unique_impl_ptr<T2, D2>::pointer;
+        using CT = typename std::common_type<P1, P2>::type;
+        return std::less<CT>()(l.get(), r.get());
+    }
+
+    template <class T1, class D1, class T2, class D2>
+    inline bool operator> (const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
+    {
+        return r < l;
+    }
+
+    template <class T1, class D1, class T2, class D2>
+    inline bool operator<=(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
+    {
+        return !(r < l);
+    }
+
+    template <class T1, class D1, class T2, class D2>
+    inline bool operator>=(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
+    {
+        return !(l < r);
+    }
+
+    template <class T, class D>
+    inline bool operator==(const unique_impl_ptr<T, D>& p, std::nullptr_t) SPIMPL_NOEXCEPT
+    {
+        return !p;
+    }
+
+    template <class T, class D>
+    inline bool operator==(std::nullptr_t, const unique_impl_ptr<T, D>& p) SPIMPL_NOEXCEPT
+    {
+        return !p;
+    }
+
+    template <class T, class D>
+    inline bool operator!=(const unique_impl_ptr<T, D>& p, std::nullptr_t) SPIMPL_NOEXCEPT
+    {
+        return static_cast<bool>(p);
+    }
+
+    template <class T, class D>
+    inline bool operator!=(std::nullptr_t, const unique_impl_ptr<T, D>& p) SPIMPL_NOEXCEPT
+    {
+        return static_cast<bool>(p);
+    }
+
+    template <class T, class D>
+    inline bool operator< (const unique_impl_ptr<T, D>& l, std::nullptr_t)
+    {
+        using P = typename unique_impl_ptr<T, D>::pointer;
+        return std::less<P>()(l.get(), nullptr);
+    }
+
+    template <class T, class D>
+    inline bool operator< (std::nullptr_t, const unique_impl_ptr<T, D>& p)
+    {
+        using P = typename unique_impl_ptr<T, D>::pointer;
+        return std::less<P>()(nullptr, p.get());
+    }
+
+    template <class T, class D>
+    inline bool operator> (const unique_impl_ptr<T, D>& p, std::nullptr_t)
+    {
+        return nullptr < p;
+    }
+
+    template <class T, class D>
+    inline bool operator> (std::nullptr_t, const unique_impl_ptr<T, D>& p)
+    {
+        return p < nullptr;
+    }
+
+    template <class T, class D>
+    inline bool operator<=(const unique_impl_ptr<T, D>& p, std::nullptr_t)
+    {
+        return !(nullptr < p);
+    }
+
+    template <class T, class D>
+    inline bool operator<=(std::nullptr_t, const unique_impl_ptr<T, D>& p)
+    {
+        return !(p < nullptr);
+    }
+
+    template <class T, class D>
+    inline bool operator>=(const unique_impl_ptr<T, D>& p, std::nullptr_t)
+    {
+        return !(p < nullptr);
+    }
+
+    template <class T, class D>
+    inline bool operator>=(std::nullptr_t, const unique_impl_ptr<T, D>& p)
+    {
+        return !(nullptr < p);
+    }
+
+
+    template<class T, class... Args>
+    inline unique_impl_ptr<T> make_unique_impl(Args&&... args)
+    {
+        return unique_impl_ptr<T>(new T(std::forward<Args>(args)...), &details::default_delete<T>);
+    }
+
+
+    // Helpers to manage unique impl, stored in std::unique_ptr
+    template<class T, class Deleter = details::default_deleter_t<T>, class Copier = details::default_copier_t<T>>
+    class impl_ptr : public unique_impl_ptr<T, Deleter>
+    {
+    public:
+        using pointer = typename unique_impl_ptr<T, Deleter>::pointer;
+        using const_pointer = typename unique_impl_ptr<T, Deleter>::const_pointer;
+        using reference = typename unique_impl_ptr<T, Deleter>::reference;
+        using const_reference = typename unique_impl_ptr<T, Deleter>::const_reference;
+        using element_type = typename unique_impl_ptr<T, Deleter>::element_type;
+        using deleter_type = typename unique_impl_ptr<T, Deleter>::deleter_type;
+        using unique_ptr_type = typename unique_impl_ptr<T, Deleter>::unique_ptr_type;
+        using copier_type = typename std::decay<Copier>::type;
         using is_default_manageable = details::is_default_manageable<T, deleter_type, copier_type>;
+        using dummy_t_ = typename unique_impl_ptr<T, Deleter>::dummy_t_;
 
         SPIMPL_CONSTEXPR impl_ptr() SPIMPL_NOEXCEPT
-        : ptr_(nullptr, deleter_type{}), copier_(copier_type{}) {}
+        : unique_impl_ptr<T, Deleter>(nullptr, deleter_type{}), copier_(copier_type{}) {}
 
         SPIMPL_CONSTEXPR impl_ptr(std::nullptr_t) SPIMPL_NOEXCEPT
         : impl_ptr() {}
@@ -126,9 +401,9 @@ namespace spimpl {
                  typename std::enable_if<
                     std::is_convertible<D, deleter_type>::value
                         && std::is_convertible<C, copier_type>::value,
-                    dummy_t_
-                 >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : ptr_(std::move(p), std::forward<D>(d)), copier_(std::forward<C>(c)) {}
+                    typename unique_impl_ptr<T, Deleter>::dummy_t_
+                 >::type = typename unique_impl_ptr<T, Deleter>::dummy_t_()) SPIMPL_NOEXCEPT
+        : unique_impl_ptr<T, Deleter>(std::move(p), std::forward<D>(d)), copier_(std::forward<C>(c)) {}
 
         template<class U>
         impl_ptr(U *u,
@@ -146,7 +421,7 @@ namespace spimpl {
         impl_ptr(impl_ptr&& r) SPIMPL_NOEXCEPT = default;
 #else
         impl_ptr(impl_ptr&& r) SPIMPL_NOEXCEPT
-        : ptr_(std::move(r.ptr_)), copier_(std::move(r.copier_)) {}
+        : unique_impl_ptr<T, Deleter>(std::move(r.ptr_)), copier_(std::move(r.copier_)) {}
 #endif
 
 #ifdef SPIMPL_HAS_AUTO_PTR
@@ -157,7 +432,7 @@ namespace spimpl {
                         && is_default_manageable::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : ptr_(u.release(), &details::default_delete<T>), copier_(&details::default_copy<T>) {}
+        : unique_impl_ptr<T, Deleter>(u.release(), &details::default_delete<T>), copier_(&details::default_copy<T>) {}
 #endif
 
         template<class U>
@@ -167,27 +442,25 @@ namespace spimpl {
                         && is_default_manageable::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : ptr_(u.release(), &details::default_delete<T>), copier_(&details::default_copy<T>) {}
+        : unique_impl_ptr<T, Deleter>(u.release(), &details::default_delete<T>) {}
 
         template<class U, class D, class C>
         impl_ptr(std::unique_ptr<U, D>&& u, C&& c,
                  typename std::enable_if<
                     std::is_convertible<U*, pointer>::value
-                        && std::is_convertible<D, deleter_type>::value
-                        && std::is_convertible<C, copier_type>::value,
+                        && std::is_convertible<D, deleter_type>::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : ptr_(std::move(u)), copier_(std::forward<C>(c)) {}
+        : unique_impl_ptr<T, Deleter>(std::move(u)), copier_(std::forward<C>(c)) {}
 
         template<class U, class D, class C>
         impl_ptr(impl_ptr<U, D, C>&& u,
                  typename std::enable_if<
                     std::is_convertible<U*, pointer>::value
-                        && std::is_convertible<D, deleter_type>::value
-                        && std::is_convertible<C, copier_type>::value,
+                        && std::is_convertible<D, deleter_type>::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : ptr_(std::move(u.ptr_)), copier_(std::move(u.copier_)) {}
+        : unique_impl_ptr<T, Deleter>(std::move(u.ptr_)), copier_(std::move(u.copier_)) {}
 
         impl_ptr& operator= (const impl_ptr& r)
         {
@@ -201,24 +474,11 @@ namespace spimpl {
         impl_ptr& operator= (impl_ptr&& r) SPIMPL_NOEXCEPT = default;
 #else
         impl_ptr& operator= (impl_ptr&& r) SPIMPL_NOEXCEPT {
-            ptr_ = std::move(r.ptr_);
+            unique_impl_ptr<T, Deleter>::ptr_ = std::move(r.ptr_);
             copier_ = std::move(r.copier_);
             return *this;
         }
 #endif
-
-        template<class U, class D, class C>
-        typename std::enable_if<
-            std::is_convertible<U*, pointer>::value
-                && std::is_convertible<D, deleter_type>::value
-                && std::is_convertible<C, copier_type>::value,
-            impl_ptr&
-        >::type operator= (impl_ptr<U, D, C>&& u) SPIMPL_NOEXCEPT
-        {
-            ptr_ = std::move(u.ptr_);
-            copier_ = std::move(u.copier_);
-            return *this;
-        }
 
         template<class U, class D, class C>
         typename std::enable_if<
@@ -255,194 +515,52 @@ namespace spimpl {
             return operator=(impl_ptr(std::move(u)));
         }
 
-        impl_ptr clone() const
+        template<class U, class D, class C>
+        typename std::enable_if<
+            std::is_convertible<U*, pointer>::value
+                && std::is_convertible<D, deleter_type>::value
+                && std::is_convertible<C, copier_type>::value,
+            impl_ptr&
+        >::type operator= (impl_ptr<U, D, C>&& u) SPIMPL_NOEXCEPT
         {
-            return impl_ptr(
-                ptr_ ? copier_(ptr_.get()) : nullptr,
-                ptr_.get_deleter(),
-                copier_);
+            unique_impl_ptr<T, Deleter>::ptr_ = std::move(u.ptr_);
+            copier_ = std::move(u.copier_);
+            return *this;
         }
-
-        reference operator*() { return *ptr_; }
-        const_reference operator*() const { return *ptr_; }
-
-        pointer operator->() SPIMPL_NOEXCEPT { return get(); }
-        const_pointer operator->() const SPIMPL_NOEXCEPT { return get(); }
-
-        pointer get() SPIMPL_NOEXCEPT { return ptr_.get(); }
-        const_pointer get() const SPIMPL_NOEXCEPT { return ptr_.get(); }
 
         void swap(impl_ptr& u) SPIMPL_NOEXCEPT
         {
             using std::swap;
-            ptr_.swap(u.ptr_);
+            unique_impl_ptr<T, Deleter>::ptr_.swap(u.ptr_);
             swap(copier_, u.copier_);
         }
 
-        pointer release() SPIMPL_NOEXCEPT { return ptr_.release(); }
+        impl_ptr clone() const
+        {
+            return impl_ptr(
+                unique_impl_ptr<T, Deleter>::ptr_ ? copier_(unique_impl_ptr<T, Deleter>::ptr_.get()) : nullptr,
+                unique_impl_ptr<T, Deleter>::ptr_.get_deleter(),
+                copier_);
+        }
 
-        unique_ptr_type release_unique() SPIMPL_NOEXCEPT { return std::move(ptr_); }
-
-        explicit operator bool() const SPIMPL_NOEXCEPT { return static_cast<bool>(ptr_); }
-
-        typename std::remove_reference<deleter_type>::type& get_deleter() SPIMPL_NOEXCEPT { return ptr_.get_deleter(); }
-        const typename std::remove_reference<deleter_type>::type& get_deleter() const SPIMPL_NOEXCEPT { return ptr_.get_deleter(); }
-
-        typename std::remove_reference<copier_type>::type& get_copier() SPIMPL_NOEXCEPT { return copier_; }
         const typename std::remove_reference<copier_type>::type& get_copier() const SPIMPL_NOEXCEPT { return copier_; }
-
+        typename std::remove_reference<copier_type>::type& get_copier() SPIMPL_NOEXCEPT { return copier_; }
     private:
-        unique_ptr_type ptr_;
         copier_type copier_;
     };
-
-
-    template<class T, class D, class C>
-    inline void swap(impl_ptr<T, D, C>& l, impl_ptr<T, D, C>& r) SPIMPL_NOEXCEPT
-    {
-        l.swap(r);
-    }
-
-
-    template <class T1, class D1, class C1, class T2, class D2, class C2>
-    inline bool operator==(const impl_ptr<T1, D1, C1>& l, const impl_ptr<T2, D2, C2>& r)
-    {
-        return l.get() == r.get();
-    }
-
-    template <class T1, class D1, class C1, class T2, class D2, class C2>
-    inline bool operator!=(const impl_ptr<T1, D1, C1>& l, const impl_ptr<T2, D2, C2>& r)
-    {
-        return !(l == r);
-    }
-
-    template <class T1, class D1, class C1, class T2, class D2, class C2>
-    inline bool operator< (const impl_ptr<T1, D1, C1>& l, const impl_ptr<T2, D2, C2>& r)
-    {
-        using P1 = typename impl_ptr<T1, D1, C1>::pointer;
-        using P2 = typename impl_ptr<T2, D2, C2>::pointer;
-        using CT = typename std::common_type<P1, P2>::type;
-        return std::less<CT>()(l.get(), r.get());
-    }
-
-    template <class T1, class D1, class C1, class T2, class D2, class C2>
-    inline bool operator> (const impl_ptr<T1, D1, C1>& l, const impl_ptr<T2, D2, C2>& r)
-    {
-        return r < l;
-    }
-
-    template <class T1, class D1, class C1, class T2, class D2, class C2>
-    inline bool operator<=(const impl_ptr<T1, D1, C1>& l, const impl_ptr<T2, D2, C2>& r)
-    {
-        return !(r < l);
-    }
-
-    template <class T1, class D1, class C1, class T2, class D2, class C2>
-    inline bool operator>=(const impl_ptr<T1, D1, C1>& l, const impl_ptr<T2, D2, C2>& r)
-    {
-        return !(l < r);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator==(const impl_ptr<T, D, C>& p, std::nullptr_t) SPIMPL_NOEXCEPT
-    {
-        return !p;
-    }
-
-    template <class T, class D, class C>
-    inline bool operator==(std::nullptr_t, const impl_ptr<T, D, C>& p) SPIMPL_NOEXCEPT
-    {
-        return !p;
-    }
-
-    template <class T, class D, class C>
-    inline bool operator!=(const impl_ptr<T, D, C>& p, std::nullptr_t) SPIMPL_NOEXCEPT
-    {
-        return static_cast<bool>(p);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator!=(std::nullptr_t, const impl_ptr<T, D, C>& p) SPIMPL_NOEXCEPT
-    {
-        return static_cast<bool>(p);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator< (const impl_ptr<T, D, C>& l, std::nullptr_t)
-    {
-        using P = typename impl_ptr<T, D, C>::pointer;
-        return std::less<P>()(l.get(), nullptr);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator< (std::nullptr_t, const impl_ptr<T, D, C>& p)
-    {
-        using P = typename impl_ptr<T, D, C>::pointer;
-        return std::less<P>()(nullptr, p.get());
-    }
-
-    template <class T, class D, class C>
-    inline bool operator> (const impl_ptr<T, D, C>& p, std::nullptr_t)
-    {
-        return nullptr < p;
-    }
-
-    template <class T, class D, class C>
-    inline bool operator> (std::nullptr_t, const impl_ptr<T, D, C>& p)
-    {
-        return p < nullptr;
-    }
-
-    template <class T, class D, class C>
-    inline bool operator<=(const impl_ptr<T, D, C>& p, std::nullptr_t)
-    {
-        return !(nullptr < p);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator<=(std::nullptr_t, const impl_ptr<T, D, C>& p)
-    {
-        return !(p < nullptr);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator>=(const impl_ptr<T, D, C>& p, std::nullptr_t)
-    {
-        return !(p < nullptr);
-    }
-
-    template <class T, class D, class C>
-    inline bool operator>=(std::nullptr_t, const impl_ptr<T, D, C>& p)
-    {
-        return !(nullptr < p);
-    }
-
 
     template<class T, class... Args>
     inline impl_ptr<T> make_impl(Args&&... args)
     {
         return impl_ptr<T>(new T(std::forward<Args>(args)...), &details::default_delete<T>, &details::default_copy<T>);
     }
-
-
-    // Helpers to manage unique impl, stored in std::unique_ptr
-
-    template<class T, class Deleter = void(*)(T*)>
-    using unique_impl_ptr = std::unique_ptr<T, Deleter>;
-
-    template<class T, class... Args>
-    inline unique_impl_ptr<T> make_unique_impl(Args&&... args)
-    {
-        static_assert(!std::is_array<T>::value, "unique_impl_ptr does not support arrays");
-        return unique_impl_ptr<T>(new T(std::forward<Args>(args)...), &details::default_delete<T>);
-    }
 }
 
 namespace std {
-    template <class T, class D, class C>
-    struct hash<spimpl::impl_ptr<T, D, C>>
+    template <class T, class D>
+    struct hash<spimpl::unique_impl_ptr<T, D>>
     {
-        using argument_type = spimpl::impl_ptr<T, D, C> ;
+        using argument_type = spimpl::unique_impl_ptr<T, D> ;
         using result_type = size_t;
 
         result_type operator()(const argument_type& p) const SPIMPL_NOEXCEPT

--- a/spimpl.h
+++ b/spimpl.h
@@ -378,20 +378,21 @@ namespace spimpl {
     template<class T, class Deleter = details::default_deleter_t<T>, class Copier = details::default_copier_t<T>>
     class impl_ptr : public unique_impl_ptr<T, Deleter>
     {
+        using base_type = unique_impl_ptr<T, Deleter>;
+        using dummy_t_ = typename base_type::dummy_t_;
     public:
-        using pointer = typename unique_impl_ptr<T, Deleter>::pointer;
-        using const_pointer = typename unique_impl_ptr<T, Deleter>::const_pointer;
-        using reference = typename unique_impl_ptr<T, Deleter>::reference;
-        using const_reference = typename unique_impl_ptr<T, Deleter>::const_reference;
-        using element_type = typename unique_impl_ptr<T, Deleter>::element_type;
-        using deleter_type = typename unique_impl_ptr<T, Deleter>::deleter_type;
-        using unique_ptr_type = typename unique_impl_ptr<T, Deleter>::unique_ptr_type;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using element_type = typename base_type::element_type;
+        using deleter_type = typename base_type::deleter_type;
+        using unique_ptr_type = typename base_type::unique_ptr_type;
         using copier_type = typename std::decay<Copier>::type;
         using is_default_manageable = details::is_default_manageable<T, deleter_type, copier_type>;
-        using dummy_t_ = typename unique_impl_ptr<T, Deleter>::dummy_t_;
 
         SPIMPL_CONSTEXPR impl_ptr() SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(nullptr, deleter_type{}), copier_(copier_type{}) {}
+        : base_type(nullptr, deleter_type{}), copier_(copier_type{}) {}
 
         SPIMPL_CONSTEXPR impl_ptr(std::nullptr_t) SPIMPL_NOEXCEPT
         : impl_ptr() {}
@@ -401,9 +402,9 @@ namespace spimpl {
                  typename std::enable_if<
                     std::is_convertible<D, deleter_type>::value
                         && std::is_convertible<C, copier_type>::value,
-                    typename unique_impl_ptr<T, Deleter>::dummy_t_
-                 >::type = typename unique_impl_ptr<T, Deleter>::dummy_t_()) SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(std::move(p), std::forward<D>(d)), copier_(std::forward<C>(c)) {}
+                    typename base_type::dummy_t_
+                 >::type = typename base_type::dummy_t_()) SPIMPL_NOEXCEPT
+        : base_type(std::move(p), std::forward<D>(d)), copier_(std::forward<C>(c)) {}
 
         template<class U>
         impl_ptr(U *u,
@@ -421,7 +422,7 @@ namespace spimpl {
         impl_ptr(impl_ptr&& r) SPIMPL_NOEXCEPT = default;
 #else
         impl_ptr(impl_ptr&& r) SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(std::move(r.ptr_)), copier_(std::move(r.copier_)) {}
+        : base_type(std::move(r.ptr_)), copier_(std::move(r.copier_)) {}
 #endif
 
 #ifdef SPIMPL_HAS_AUTO_PTR
@@ -432,7 +433,7 @@ namespace spimpl {
                         && is_default_manageable::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(u.release(), &details::default_delete<T>), copier_(&details::default_copy<T>) {}
+        : base_type(u.release(), &details::default_delete<T>), copier_(&details::default_copy<T>) {}
 #endif
 
         template<class U>
@@ -442,7 +443,7 @@ namespace spimpl {
                         && is_default_manageable::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(u.release(), &details::default_delete<T>) {}
+        : base_type(u.release(), &details::default_delete<T>) {}
 
         template<class U, class D, class C>
         impl_ptr(std::unique_ptr<U, D>&& u, C&& c,
@@ -451,7 +452,7 @@ namespace spimpl {
                         && std::is_convertible<D, deleter_type>::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(std::move(u)), copier_(std::forward<C>(c)) {}
+        : base_type(std::move(u)), copier_(std::forward<C>(c)) {}
 
         template<class U, class D, class C>
         impl_ptr(impl_ptr<U, D, C>&& u,
@@ -460,7 +461,7 @@ namespace spimpl {
                         && std::is_convertible<D, deleter_type>::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : unique_impl_ptr<T, Deleter>(std::move(u.ptr_)), copier_(std::move(u.copier_)) {}
+        : base_type(std::move(u.ptr_)), copier_(std::move(u.copier_)) {}
 
         impl_ptr& operator= (const impl_ptr& r)
         {
@@ -474,7 +475,7 @@ namespace spimpl {
         impl_ptr& operator= (impl_ptr&& r) SPIMPL_NOEXCEPT = default;
 #else
         impl_ptr& operator= (impl_ptr&& r) SPIMPL_NOEXCEPT {
-            unique_impl_ptr<T, Deleter>::ptr_ = std::move(r.ptr_);
+            base_type::ptr_ = std::move(r.ptr_);
             copier_ = std::move(r.copier_);
             return *this;
         }
@@ -523,7 +524,7 @@ namespace spimpl {
             impl_ptr&
         >::type operator= (impl_ptr<U, D, C>&& u) SPIMPL_NOEXCEPT
         {
-            unique_impl_ptr<T, Deleter>::ptr_ = std::move(u.ptr_);
+            base_type::ptr_ = std::move(u.ptr_);
             copier_ = std::move(u.copier_);
             return *this;
         }
@@ -531,15 +532,15 @@ namespace spimpl {
         void swap(impl_ptr& u) SPIMPL_NOEXCEPT
         {
             using std::swap;
-            unique_impl_ptr<T, Deleter>::ptr_.swap(u.ptr_);
+            base_type::ptr_.swap(u.ptr_);
             swap(copier_, u.copier_);
         }
 
         impl_ptr clone() const
         {
             return impl_ptr(
-                unique_impl_ptr<T, Deleter>::ptr_ ? copier_(unique_impl_ptr<T, Deleter>::ptr_.get()) : nullptr,
-                unique_impl_ptr<T, Deleter>::ptr_.get_deleter(),
+                base_type::ptr_ ? copier_(base_type::ptr_.get()) : nullptr,
+                base_type::ptr_.get_deleter(),
                 copier_);
         }
 
@@ -554,6 +555,12 @@ namespace spimpl {
     {
         return impl_ptr<T>(new T(std::forward<Args>(args)...), &details::default_delete<T>, &details::default_copy<T>);
     }
+
+    template<class T, class D, class C>
+    inline void swap(impl_ptr<T, D, C>& l,impl_ptr<T, D, C>& r) SPIMPL_NOEXCEPT
+    {
+        l.swap(r);
+    }
 }
 
 namespace std {
@@ -561,6 +568,18 @@ namespace std {
     struct hash<spimpl::unique_impl_ptr<T, D>>
     {
         using argument_type = spimpl::unique_impl_ptr<T, D> ;
+        using result_type = size_t;
+
+        result_type operator()(const argument_type& p) const SPIMPL_NOEXCEPT
+        {
+            return hash<typename argument_type::pointer>()(p.get());
+        }
+    };
+
+    template <class T, class D, class C>
+    struct hash<spimpl::impl_ptr<T, D, C>>
+    {
+        using argument_type = spimpl::impl_ptr<T, D, C> ;
         using result_type = size_t;
 
         result_type operator()(const argument_type& p) const SPIMPL_NOEXCEPT


### PR DESCRIPTION
This fixes #5. Because copying and editing all the stuff for `impl_ptr` leads to a lot of code duplication and is error prone, I have used an alternative approach that makes `impl_unique_ptr` inherit from `std::unique_ptr` and const-qualify the return values of its access methods if necessary.

Inheriting from std is not an issue here because the inherited class has no members and doesn't need any methods to be virtual.