### PR TITLE
unique_impl_ptr: fix broken ctor

### DIFF
--- a/spimpl.h
+++ b/spimpl.h
@@ -135,7 +135,7 @@ namespace spimpl {
                         && is_default_manageable::value,
                     dummy_t_
                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
-        : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
+        : unique_impl_ptr(u, &details::default_delete<T>) {}
 
 #ifndef SPIMPL_NO_CPP11_DEFAULT_MOVE_SPEC_FUNC
         unique_impl_ptr(unique_impl_ptr&& r) SPIMPL_NOEXCEPT = default;


### PR DESCRIPTION
This looks like a bad copy paste from `impl_ptr`. I consider it a pretty severe error.

Sample program showcasing the problem:

```cpp
#include "spimpl.h"

int main()
{
    int * test = new int;
    spimpl::unique_impl_ptr<int> instance(test);
}
```

<details><summary>gcc error output</summary>
<p>

```
In file included from test.cpp:1:
spimpl.h: In instantiation of 'spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(U*, typename std::enable_if<(std::is_convertible<_Up*, _Tp*>::value && spimpl::details::is_default_manageable<T, typename std::decay<_Tp2>::type>::value), dummy_t_>::type) [with U = int; T = int; Deleter = void (*)(int*); typename std::enable_if<(std::is_convertible<_Up*, _Tp*>::value && spimpl::details::is_default_manageable<T, typename std::decay<_Tp2>::type>::value), dummy_t_>::type = spimpl::unique_impl_ptr<int>::dummy_t_; typename std::decay<_Tp2>::type = void (*)(int*); typename spimpl::details::default_copier<T>::type = int* (*)(int*)]':
test.cpp:6:47:   required from here
spimpl.h:138:84: error: no matching function for call to 'spimpl::unique_impl_ptr<int>::unique_impl_ptr(int*&, <unresolved overloaded function type>, <unresolved overloaded function type>)'
  138 |         : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
      |                                                                                    ^
spimpl.h:177:9: note: candidate: 'template<class U, class D> spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(spimpl::unique_impl_ptr<U, D>&&, typename std::enable_if<(std::is_convertible<_Up*, _Tp*>::value && std::is_convertible<D, typename std::decay<_Tp2>::type>::value), dummy_t_>::type) [with D = U; T = int; Deleter = void (*)(int*)]'
  177 |         unique_impl_ptr(unique_impl_ptr<U, D>&& u,
      |         ^~~~~~~~~~~~~~~
spimpl.h:177:9: note:   template argument deduction/substitution failed:
spimpl.h:138:84: note:   mismatched types 'spimpl::unique_impl_ptr<T, D>' and 'int*'
  138 |         : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
      |                                                                                    ^
spimpl.h:168:9: note: candidate: 'template<class U, class D> spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(std::unique_ptr<_Up, _Ep>&&, typename std::enable_if<(std::is_convertible<_Up*, _Tp*>::value && std::is_convertible<D, typename std::decay<_Tp2>::type>::value), dummy_t_>::type) [with D = U; T = int; Deleter = void (*)(int*)]'
  168 |         unique_impl_ptr(std::unique_ptr<U, D>&& u,
      |         ^~~~~~~~~~~~~~~
spimpl.h:168:9: note:   template argument deduction/substitution failed:
spimpl.h:138:84: note:   mismatched types 'std::unique_ptr<_Tp, _Dp>' and 'int*'
  138 |         : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
      |                                                                                    ^
spimpl.h:159:9: note: candidate: 'template<class U> spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(std::unique_ptr<U>&&, typename std::enable_if<(std::is_convertible<_Up*, _Tp*>::value && spimpl::details::is_default_manageable<T, typename std::decay<_Tp2>::type>::value), dummy_t_>::type) [with T = int; Deleter = void (*)(int*)]'
  159 |         unique_impl_ptr(std::unique_ptr<U>&& u,
      |         ^~~~~~~~~~~~~~~
spimpl.h:159:9: note:   template argument deduction/substitution failed:
spimpl.h:138:84: note:   mismatched types 'std::unique_ptr<_Tp>' and 'int*'
  138 |         : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
      |                                                                                    ^
spimpl.h:132:9: note: candidate: 'template<class U> spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(U*, typename std::enable_if<(std::is_convertible<_Up*, _Tp*>::value && spimpl::details::is_default_manageable<T, typename std::decay<_Tp2>::type>::value), dummy_t_>::type) [with T = int; Deleter = void (*)(int*)]'
  132 |         unique_impl_ptr(U *u,
      |         ^~~~~~~~~~~~~~~
spimpl.h:132:9: note:   template argument deduction/substitution failed:
spimpl.h:138:84: note:   candidate expects 2 arguments, 3 provided
  138 |         : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
      |                                                                                    ^
spimpl.h:124:9: note: candidate: 'spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(pointer, D&&, typename std::enable_if<std::is_convertible<D, typename std::decay<_Tp2>::type>::value, dummy_t_>::type) [with D = void (*)(int*) noexcept; T = int; Deleter = void (*)(int*); pointer = int*; typename std::enable_if<std::is_convertible<D, typename std::decay<_Tp2>::type>::value, dummy_t_>::type = spimpl::unique_impl_ptr<int>::dummy_t_; typename std::decay<_Tp2>::type = void (*)(int*)]'
  124 |         unique_impl_ptr(pointer p, D&& d,
      |         ^~~~~~~~~~~~~~~
spimpl.h:125:18: note:   no known conversion for argument 3 from '<unresolved overloaded function type>' to 'std::enable_if<true, spimpl::unique_impl_ptr<int>::dummy_t_>::type' {aka 'spimpl::unique_impl_ptr<int>::dummy_t_'}
  125 |                  typename std::enable_if<
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~
  126 |                     std::is_convertible<D, deleter_type>::value,
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  127 |                     dummy_t_
      |                     ~~~~~~~~
  128 |                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
      |                  ~~~~~~~~~~~~~~~~~~~~
spimpl.h:141:9: note: candidate: 'spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(spimpl::unique_impl_ptr<T, Deleter>&&) [with T = int; Deleter = void (*)(int*)]'
  141 |         unique_impl_ptr(unique_impl_ptr&& r) SPIMPL_NOEXCEPT = default;
      |         ^~~~~~~~~~~~~~~
spimpl.h:141:9: note:   candidate expects 1 argument, 3 provided
spimpl.h:120:26: note: candidate: 'constexpr spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr(std::nullptr_t) [with T = int; Deleter = void (*)(int*); std::nullptr_t = std::nullptr_t]'
  120 |         SPIMPL_CONSTEXPR unique_impl_ptr(std::nullptr_t) SPIMPL_NOEXCEPT
      |                          ^~~~~~~~~~~~~~~
spimpl.h:120:26: note:   candidate expects 1 argument, 3 provided
spimpl.h:117:26: note: candidate: 'constexpr spimpl::unique_impl_ptr<T, Deleter>::unique_impl_ptr() [with T = int; Deleter = void (*)(int*)]'
  117 |         SPIMPL_CONSTEXPR unique_impl_ptr() SPIMPL_NOEXCEPT
      |                          ^~~~~~~~~~~~~~~
spimpl.h:117:26: note:   candidate expects 0 arguments, 3 provided
```

</p>
</details>

<details><summary>clang error output</summary>
<p>

```
In file included from test.cpp:1:
./spimpl.h:138:11: error: no matching constructor for initialization of 'spimpl::unique_impl_ptr<int>'
  138 |         : unique_impl_ptr(u, &details::default_delete<T>, &details::default_copy<T>) {}
      |           ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test.cpp:6:34: note: in instantiation of function template specialization 'spimpl::unique_impl_ptr<int>::unique_impl_ptr<int>' requested here
    6 |     spimpl::unique_impl_ptr<int> instance(test);
      |                                  ^
./spimpl.h:124:9: note: candidate constructor [with D = void (*)(int *) noexcept] not viable: no overload of 'default_copy' matching 'typename std::enable_if<std::is_convertible<void (*)(int *) noexcept, deleter_type>::value, dummy_t_>::type' (aka 'spimpl::unique_impl_ptr<int>::dummy_t_') for 3rd argument
  124 |         unique_impl_ptr(pointer p, D&& d,
      |         ^
  125 |                  typename std::enable_if<
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
  126 |                     std::is_convertible<D, deleter_type>::value,
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  127 |                     dummy_t_
      |                     ~~~~~~~~
  128 |                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
      |                  ~~~~~~~~~~~~~~~~~~~~
./spimpl.h:132:9: note: candidate constructor template not viable: requires at most 2 arguments, but 3 were provided
  132 |         unique_impl_ptr(U *u,
      |         ^               ~~~~~
  133 |                  typename std::enable_if<
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
  134 |                     std::is_convertible<U*, pointer>::value
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  135 |                         && is_default_manageable::value,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  136 |                     dummy_t_
      |                     ~~~~~~~~
  137 |                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
      |                  ~~~~~~~~~~~~~~~~~~~~
./spimpl.h:159:9: note: candidate constructor template not viable: requires at most 2 arguments, but 3 were provided
  159 |         unique_impl_ptr(std::unique_ptr<U>&& u,
      |         ^               ~~~~~~~~~~~~~~~~~~~~~~~
  160 |                  typename std::enable_if<
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
  161 |                     std::is_convertible<U*, pointer>::value
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  162 |                         && is_default_manageable::value,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  163 |                     dummy_t_
      |                     ~~~~~~~~
  164 |                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
      |                  ~~~~~~~~~~~~~~~~~~~~
./spimpl.h:168:9: note: candidate constructor template not viable: requires at most 2 arguments, but 3 were provided
  168 |         unique_impl_ptr(std::unique_ptr<U, D>&& u,
      |         ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~
  169 |                  typename std::enable_if<
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
  170 |                     std::is_convertible<U*, pointer>::value
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  171 |                         && std::is_convertible<D, deleter_type>::value,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  172 |                     dummy_t_
      |                     ~~~~~~~~
  173 |                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
      |                  ~~~~~~~~~~~~~~~~~~~~
./spimpl.h:177:9: note: candidate constructor template not viable: requires at most 2 arguments, but 3 were provided
  177 |         unique_impl_ptr(unique_impl_ptr<U, D>&& u,
      |         ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~
  178 |                  typename std::enable_if<
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
  179 |                     std::is_convertible<U*, pointer>::value
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  180 |                         && std::is_convertible<D, deleter_type>::value,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  181 |                     dummy_t_
      |                     ~~~~~~~~
  182 |                  >::type = dummy_t_()) SPIMPL_NOEXCEPT
      |                  ~~~~~~~~~~~~~~~~~~~~
./spimpl.h:120:26: note: candidate constructor not viable: requires 1 argument, but 3 were provided
  120 |         SPIMPL_CONSTEXPR unique_impl_ptr(std::nullptr_t) SPIMPL_NOEXCEPT
      |                          ^               ~~~~~~~~~~~~~~
./spimpl.h:141:9: note: candidate constructor not viable: requires single argument 'r', but 3 arguments were provided
  141 |         unique_impl_ptr(unique_impl_ptr&& r) SPIMPL_NOEXCEPT = default;
      |         ^               ~~~~~~~~~~~~~~~~~~~
./spimpl.h:185:9: note: candidate constructor not viable: requires 1 argument, but 3 were provided
  185 |         unique_impl_ptr(const unique_impl_ptr<T, Deleter>&) = delete;
      |         ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./spimpl.h:117:26: note: candidate constructor not viable: requires 0 arguments, but 3 were provided
  117 |         SPIMPL_CONSTEXPR unique_impl_ptr() SPIMPL_NOEXCEPT
      |                          ^
1 error generated.
```

</p>
</details> 