### PR TITLE
unique_impl_ptr: fix bug in operator!=

### DIFF
--- a/spimpl.h
+++ b/spimpl.h
@@ -259,7 +259,7 @@ namespace spimpl {
         return l.get() == r.get();
     }
 
-    template <class T1, class D1, class C1, class T2, class D2>
+    template <class T1, class D1, class T2, class D2>
     inline bool operator!=(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
     {
         return !(l == r);


### PR DESCRIPTION
Likely a bad copy paste from `impl_ptr`. The additional parameter `C1` makes it impossible to use this operator without explicitly specifying all its template types, making it less useful.

Sample program showcasing the problem:

```cpp
#include "spimpl.h"

int main()
{
    auto first = spimpl::make_unique_impl<int>();
    auto second = spimpl::make_unique_impl<int>();
    first != second;
}
```

<details><summary>gcc error output</summary>
<p>

```
test.cpp: In function 'int main()':
test.cpp:7:11: error: no match for 'operator!=' (operand types are 'spimpl::unique_impl_ptr<int, void (*)(int*)>' and 'spimpl::unique_impl_ptr<int, void (*)(int*)>')
    7 |     first != second;
      |     ~~~~~ ^~ ~~~~~~
      |     |        |
      |     |        unique_impl_ptr<[...],[...]>
      |     unique_impl_ptr<[...],[...]>
test.cpp:7:11: note: candidate: 'operator!=(int, int)' (built-in)
    7 |     first != second;
      |     ~~~~~~^~~~~~~~~
test.cpp:7:11: note:   no known conversion for argument 2 from 'spimpl::unique_impl_ptr<int, void (*)(int*)>' to 'int'
In file included from test.cpp:1:
spimpl.h:263:17: note: candidate: 'template<class T1, class D1, class C1, class T2, class D2> bool spimpl::operator!=(const unique_impl_ptr<T, D>&, const unique_impl_ptr<T2, D2>&)'
  263 |     inline bool operator!=(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
      |                 ^~~~~~~~
spimpl.h:263:17: note:   template argument deduction/substitution failed:
test.cpp:7:14: note:   couldn't deduce template parameter 'C1'
    7 |     first != second;
      |              ^~~~~~
spimpl.h:308:17: note: candidate: 'template<class T, class D> bool spimpl::operator!=(const unique_impl_ptr<T, D>&, std::nullptr_t)'
  308 |     inline bool operator!=(const unique_impl_ptr<T, D>& p, std::nullptr_t) SPIMPL_NOEXCEPT
      |                 ^~~~~~~~
spimpl.h:308:17: note:   template argument deduction/substitution failed:
test.cpp:7:14: note:   cannot convert 'second' (type 'spimpl::unique_impl_ptr<int, void (*)(int*)>') to type 'std::nullptr_t'
    7 |     first != second;
      |              ^~~~~~
spimpl.h:314:17: note: candidate: 'template<class T, class D> bool spimpl::operator!=(std::nullptr_t, const unique_impl_ptr<T, D>&)'
  314 |     inline bool operator!=(std::nullptr_t, const unique_impl_ptr<T, D>& p) SPIMPL_NOEXCEPT
      |                 ^~~~~~~~
spimpl.h:314:17: note:   template argument deduction/substitution failed:
test.cpp:7:5: note:   cannot convert 'first' (type 'spimpl::unique_impl_ptr<int, void (*)(int*)>') to type 'std::nullptr_t'
    7 |     first != second;
      |     ^~~~~
```

</p>
</details> 

<details><summary>clang error output</summary>
<p>

```
test.cpp:7:11: error: invalid operands to binary expression ('unique_impl_ptr<int>' and 'unique_impl_ptr<int>')
    7 |     first != second;
      |     ~~~~~ ^  ~~~~~~
./spimpl.h:308:17: note: candidate function template not viable: no known conversion from 'unique_impl_ptr<int>' to 'std::nullptr_t' for 2nd argument
  308 |     inline bool operator!=(const unique_impl_ptr<T, D>& p, std::nullptr_t) SPIMPL_NOEXCEPT
      |                 ^                                          ~~~~~~~~~~~~~~
./spimpl.h:314:17: note: candidate function template not viable: no known conversion from 'unique_impl_ptr<int>' to 'std::nullptr_t' for 1st argument
  314 |     inline bool operator!=(std::nullptr_t, const unique_impl_ptr<T, D>& p) SPIMPL_NOEXCEPT
      |                 ^          ~~~~~~~~~~~~~~
./spimpl.h:263:17: note: candidate template ignored: couldn't infer template argument 'C1'
  263 |     inline bool operator!=(const unique_impl_ptr<T1, D1>& l, const unique_impl_ptr<T2, D2>& r)
      |                 ^
1 error generated.
```

</p>
</details> 